### PR TITLE
Add title filter parameter to items_filters route

### DIFF
--- a/backend/app/api/dependencies/items.py
+++ b/backend/app/api/dependencies/items.py
@@ -19,6 +19,7 @@ from app.services.items import check_user_can_modify_item
 
 
 def get_items_filters(
+    title: Optional[str] = None,
     tag: Optional[str] = None,
     seller: Optional[str] = None,
     favorited: Optional[str] = None,
@@ -26,6 +27,7 @@ def get_items_filters(
     offset: int = Query(DEFAULT_ITEMS_OFFSET, ge=0),
 ) -> ItemsFilters:
     return ItemsFilters(
+        title=title,
         tag=tag,
         seller=seller,
         favorited=favorited,

--- a/backend/app/api/routes/items/items_resource.py
+++ b/backend/app/api/routes/items/items_resource.py
@@ -35,6 +35,7 @@ async def list_items(
     items_repo: ItemsRepository = Depends(get_repository(ItemsRepository)),
 ) -> ListOfItemsInResponse:
     items = await items_repo.filter_items(
+        title=items_filters.title,
         tag=items_filters.tag,
         seller=items_filters.seller,
         favorited=items_filters.favorited,

--- a/backend/app/db/repositories/items.py
+++ b/backend/app/db/repositories/items.py
@@ -139,12 +139,12 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
         # fmt: on
 
         if title:
-            query_params.append(title)
+            query_params.append("%" + title + "%")
             query_params_count += 1
 
             # fmt: off
             query = query.where(
-                items.title == Parameter(query_params_count)
+                items.title.like(Parameter(query_params_count))
             )
             # fmt: on
 

--- a/backend/app/db/repositories/items.py
+++ b/backend/app/db/repositories/items.py
@@ -103,6 +103,7 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
     async def filter_items(  # noqa: WPS211
         self,
         *,
+        title: Optional[str] = None,
         tag: Optional[str] = None,
         seller: Optional[str] = None,
         favorited: Optional[str] = None,
@@ -136,6 +137,16 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
             ),
         )
         # fmt: on
+
+        if title:
+            query_params.append(title)
+            query_params_count += 1
+
+            # fmt: off
+            query = query.where(
+                items.title == Parameter(query_params_count)
+            )
+            # fmt: on
 
         if tag:
             query_params.append(tag)

--- a/backend/app/models/schemas/items.py
+++ b/backend/app/models/schemas/items.py
@@ -37,6 +37,7 @@ class ListOfItemsInResponse(RWSchema):
 
 
 class ItemsFilters(BaseModel):
+    title: Optional[str] = None
     tag: Optional[str] = None
     seller: Optional[str] = None
     favorited: Optional[str] = None


### PR DESCRIPTION
Enable `list_items` route to filter on item title by adding `title` attribute to `ItemsFilters` schema.
